### PR TITLE
Round 23:59:59 to midnight (00:00:00)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # azmetr (development version)
 
-- Transfered maintainance of package to Jeremy Weiss
+- Transferred maintenance of package to Jeremy Weiss
 - Timestamp for hourly and daily maximum two-minute sustained wind speeds, `wind_2min_timestamp` now appears in downloaded data
+- Hourly data now has the `date_datetime` column rounded up so that midnight is "2023-01-02 00:00:00" instead of "2023-01-01 23:59:59" (for example)
+- Corrected timezone for the `date_datetime` column returned by `az_hourly()` to be "Arizona/Phoenix"
 
 # azmetr 0.2.0
 

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -91,7 +91,7 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       as.numeric
     )) %>%
     dplyr::filter(.data$meta_station_id != "az99") %>%
-    dplyr::mutate(date_datetime = lubridate::ymd_hms(.data$date_datetime)) %>%
+    dplyr::mutate(date_datetime = lubridate::ymd_hms(.data$date_datetime, tz = "America/Phoenix")) %>%
     #convert NAs
     dplyr::mutate(
       dplyr::across(

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -91,7 +91,10 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       as.numeric
     )) %>%
     dplyr::filter(.data$meta_station_id != "az99") %>%
-    dplyr::mutate(date_datetime = lubridate::ymd_hms(.data$date_datetime, tz = "America/Phoenix")) %>%
+    dplyr::mutate(
+      date_datetime = lubridate::ymd_hms(.data$date_datetime, tz = "America/Phoenix") %>%
+        lubridate::ceiling_date("hour") #rounds 23:59:59 up to 00:00:00 (midnight)
+      ) %>%
     #convert NAs
     dplyr::mutate(
       dplyr::across(

--- a/man/station_info.Rd
+++ b/man/station_info.Rd
@@ -5,7 +5,7 @@
 \alias{station_info}
 \title{AZMet station names and locations}
 \format{
-A tibble with 28 rows and 4 columns:
+A tibble with 30 rows and 4 columns:
 \describe{
 \item{\code{meta_station_name}}{Station name}
 \item{\code{meta_station_id}}{Station ID}

--- a/vignettes/basic_use.Rmd
+++ b/vignettes/basic_use.Rmd
@@ -47,7 +47,8 @@ range(wk$datetime)
 ```{r}
 last_datetime <- max(hourly$date_datetime)
 last_datetime
-last_48h <- last_datetime - hours(48)
+#format() is used here to ensure the time part doesn't get dropped
+last_48h <- format(last_datetime - hours(48), "%Y-%m-%d %H:%M:%S")
 hr <- az_hourly(start_date_time = last_48h)
 
 range(hr$date_datetime)


### PR DESCRIPTION
Addresses #53. In the output of `az_hourly()` the `date_datetime` column is now always hourly and has the correct timezone ("America/Phoenix") associated with it.  This required an update to the vignette and made me think that addressing #44 is more important than I previously thought.