### PR TITLE
Fix for warning when end date/time not specified

### DIFF
--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -46,7 +46,6 @@
 #'
 az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
 
-  #TODO: document output columns or link to API docs if appropriate
   #TODO: check for valid station IDs
   check_internet()
   if(!is.null(end_date) & is.null(start_date)) {

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -45,7 +45,6 @@
 #'
 az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time = NULL) {
 
-  #TODO: document output columns or link to API docs if appropriate
   #TODO: check for valid station IDs
   check_internet()
   if(!is.null(end_date_time) & is.null(start_date_time)) {

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -81,9 +81,10 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
       )
   } else {
     if (hour) {
-      end <- lubridate::now()
+      #API is always about one timestep behind
+      end <- lubridate::now() - lubridate::hours(1)
     } else {
-      end <- lubridate::today()
+      end <- lubridate::today() - lubridate::days(1)
     }
   }
 

--- a/tests/testthat/test-parse_params.R
+++ b/tests/testthat/test-parse_params.R
@@ -74,9 +74,9 @@ test_that("accepts dates and date times in different formats", {
   )
 })
 
-test_that("end defaults to current date", {
+test_that("end defaults to yesterday's date", {
   start <- "2022-10-01"
-  end <- today()
+  end <- today() - days(1)
   time_interval <- format_ISO8601(as.period(ymd(end) - ymd(start)))
   params <- parse_params(station_id = NULL, start = start, end = NULL)
   expect_equal(params$time_interval, time_interval)


### PR DESCRIPTION
Fixed #58 by setting end date/time to yesterday/an hour ago when not specified.  The API is always behind by about a timestep, so this is a more reasonable default and will no longer always trigger the "some requested data is unavailable" warning.