### PR TITLE
Error when historical data is requested

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 - Improved messages regarding what date/time ranges are being queried and returned by data retrieval functions.
 - `az_hourly()` now returns data from the previous hour when `start_date_time` and `end_date_time` are not supplied rather than returning the previous day of hourly data.
 - `azmet` is now much more verbose, printing messages about which data are requested and which data are returned.
-
+- Requests for data before Jan 1, 2021 now error, since these data are not on the AZMet API (yet).
 
 # azmetr 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 - Improved messages regarding what date/time ranges are being queried and returned by data retrieval functions.
 - `az_hourly()` now returns data from the previous hour when `start_date_time` and `end_date_time` are not supplied rather than returning the previous day of hourly data.
 - `azmet` is now much more verbose, printing messages about which data are requested and which data are returned.
-- Requests for data before Jan 1, 2021 now error, since these data are not on the AZMet API (yet).
+- Requests for data before January 1, 2021 now error, since these data are not on the AZMet API (yet).
 
 # azmetr 0.2.1
 

--- a/R/az_heat.R
+++ b/R/az_heat.R
@@ -51,14 +51,14 @@
 #' }
 #'
 az_heat <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
-
+  tz <- "America/Phoenix"
   #TODO: document output columns or link to API docs if appropriate
   #TODO: check for valid station IDs
   check_internet()
   # If no start date supplied, default is Jan 1 of current year.
   if (is.null(start_date)) {
     if(is.null(end_date)) {
-      start_date <- lubridate::floor_date(lubridate::today(), "year")
+      start_date <- lubridate::floor_date(lubridate::today(tzone = tz), "year")
     } else {
       start_date <- lubridate::floor_date(lubridate::ymd(end_date), "year")
     }

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -143,7 +143,7 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
     if (!is.null(end) & end_parsed >= lubridate::floor_date(lubridate::now(tzone = tz), "hour")) {
       stop("Please supply an `end_date_time` earlier than now.")
     }
-    if(end_parsed < start_parsed) {
+    if (end_parsed < start_parsed) {
       stop("`end_date_time` is before `start_date_time`!")
     }
   #If daily
@@ -154,11 +154,14 @@ parse_params <- function(station_id, start, end, hour = FALSE) {
     if (!is.null(end) & end_parsed >= lubridate::today(tzone = tz)) {
       stop("Please supply an `end_date` earlier than today.")
     }
-    if(end_parsed < start_parsed) {
+    if (end_parsed < start_parsed) {
       stop("`end_date` is before `start_date`!")
     }
   }
-
+  earliest_date <- lubridate::ymd("2021-01-01", tz = tz)
+  if (end_parsed < earliest_date | start_parsed < earliest_date) {
+    stop("No data is available before ", earliest_date, ". Please choose a later date.")
+  }
   # Construct time interval for API -----------------------------------------
   # round_date() is necessary here because although the AZMet API counts
   # 23:59 as a valid time, it considers the time interval between 23 and 23:59

--- a/tests/testthat/test-az_daily.R
+++ b/tests/testthat/test-az_daily.R
@@ -44,6 +44,7 @@ test_that("NAs converted correctly", {
 })
 
 test_that("no data is returned as 0x0 tibble", {
+  skip("Not sure how to reproduce this anymore now that these dates error")
   suppressWarnings(
     res_nodata <-
       az_daily(start_date = "1980-01-01", end_date = "1980-01-02")

--- a/tests/testthat/test-az_heat.R
+++ b/tests/testthat/test-az_heat.R
@@ -35,6 +35,7 @@ test_that("data is in correct format", {
 })
 
 test_that("no data is returned as 0x0 tibble", {
+  skip("not sure how to reproduce this now that requests for historical data error")
   res_nodata <-
     suppressWarnings(az_heat(start_date = "1980-01-01", end_date = "1980-01-02"))
 

--- a/tests/testthat/test-az_hourly.R
+++ b/tests/testthat/test-az_hourly.R
@@ -33,6 +33,7 @@ test_that("data is in correct format", {
 })
 
 test_that("no data is returned as 0x0 tibble", {
+  skip("not sure how to reproduce this now that request for historical data error")
   res_nodata <-
     suppressWarnings(az_hourly(start_date_time = "1980-01-01 00", end_date_time = "1980-01-02 00"))
   expect_true(nrow(res_nodata) == 0)

--- a/tests/testthat/test-az_hourly.R
+++ b/tests/testthat/test-az_hourly.R
@@ -61,7 +61,8 @@ test_that("start=NULL, end=NULL works as expected", {
   }, glue::glue("Querying most recent hour of data"))
 
   expect_equal(nrow(null_null), 1)
-  expect_equal(null_null$date_datetime, latest_hour)
+  #could be that current hour hasn't hit API yet.
+  expect_in(null_null$date_datetime, c(latest_hour, latest_hour - hours(1)))
 })
 
 test_that("end=NULL works as expected", {

--- a/tests/testthat/test-parse_params.R
+++ b/tests/testthat/test-parse_params.R
@@ -167,3 +167,12 @@ test_that("start and end has to be earlier than now", {
     "Please supply an `end_date` earlier than today."
   )
 })
+
+test_that("requests for historical data error", {
+  expect_error(
+    parse_params(1, start = "2020-12-31", end = "2021-01-02")
+  )
+  expect_error(
+    parse_params(1, start = "2020-01-01", end = "2020-12-31")
+  )
+})


### PR DESCRIPTION
Adds an error message when data before Jan 1, 2021 is requested. Closes #66.