### PR TITLE
Make `azmetr` searchable in r-universe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-URL: https://uace-azmet.github.io/azmetr/, https://cct-datascience.r-universe.dev/azmetr
+URL: https://uace-azmet.github.io/azmetr/, https://uace-azmet.r-universe.dev/azmetr
 BugReports: https://github.com/uace-azmet/azmetr/issues
 Suggests: 
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-URL: https://github.com/uace-azmet/azmetr, https://uace-azmet.github.io/azmetr/
+URL: https://uace-azmet.github.io/azmetr/, https://cct-datascience.r-universe.dev/azmetr
 BugReports: https://github.com/uace-azmet/azmetr/issues
 Suggests: 
     covr,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The goal of azmetr is to provide programmatic access to the [Arizona Meteorologi
 You can install the development version of `azmetr` from r-universe:
 
 ```r
-install.packages('azmetr', repos = c('https://cct-datascience.r-universe.dev', 'https://cloud.r-project.org'))
+install.packages('azmetr', repos = c('https://uace-azmet.r-universe.dev', 'https://cloud.r-project.org'))
 ```
 
 Alternatively, you can install a development version directly from GitHub with the `remotes` package:


### PR DESCRIPTION
Currently `azmetr` is hidden from search results on r-universe.dev:

![Screenshot 2025-02-18 at 3 57 22 PM](https://github.com/user-attachments/assets/68faca45-f155-42ca-80c5-71b39f2f5a50)
(screenshot from top of https://cct-datascience.r-universe.dev/azmetr)

This PR adds https://cct-datascience.r-universe.dev/azmetr to the URL field of DESCRIPTION which will mark https://cct-datascience.r-universe.dev/azmetr as "official" and it will then be searchable.

However, another option would be to set up an r-universe for your organization so the package would be installable from https://uace-azmet.r-universe.dev/azmetr instead.  If you'd rather do that ([instructions](https://docs.r-universe.dev/publish/set-up.html)), don't merge this PR!