### PR TITLE
change rate limiting to explicitly use token bucket model

### DIFF
--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -25,8 +25,8 @@ retrieve_data <-
     httr2::req_method("GET") %>%
     httr2::req_url_path_append("observations", endpoint, station_id, start_f, time_interval) %>%
     httr2::req_headers("Accept" = "application/json") %>%
-    # Limit rate to 4 calls per second
-    httr2::req_throttle(capacity =  100, fill_time_s = 60)
+    httr2::req_throttle(capacity =  100, fill_time_s = 60) %>%
+    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)")
 
   if (isTRUE(print_call)) {
     print(req)

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -25,7 +25,7 @@ retrieve_data <-
     httr2::req_method("GET") %>%
     httr2::req_url_path_append("observations", endpoint, station_id, start_f, time_interval) %>%
     httr2::req_headers("Accept" = "application/json") %>%
-    httr2::req_throttle(capacity =  100, fill_time_s = 60) %>%
+    httr2::req_throttle(capacity =  200, fill_time_s = 60) %>%
     httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)")
 
   if (isTRUE(print_call)) {

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -26,7 +26,7 @@ retrieve_data <-
     httr2::req_url_path_append("observations", endpoint, station_id, start_f, time_interval) %>%
     httr2::req_headers("Accept" = "application/json") %>%
     # Limit rate to 4 calls per second
-    httr2::req_throttle(4 / 1)
+    httr2::req_throttle(capacity =  100, fill_time_s = 60)
 
   if (isTRUE(print_call)) {
     print(req)

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,9 @@ ping_service <- function() {
     httr2::request(base_url) %>%
     httr2::req_url_path_append("observations", "daily", "az01") %>%
     httr2::req_error(is_error = function(resp) FALSE) %>%
-    httr2::req_perform()
+    httr2::req_method("HEAD") %>%
+    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)") %>% 
+    httr2::req_perform() 
 
   status <- httr2::resp_status(resp)
   if(status == 200){


### PR DESCRIPTION
`httr2` changed the way `req_throttle()` works recently to a "token bucket" model.  E.g.  if `capacity = 10` and `fill_time_s = 60`, then the first 10 requests can happen without waiting, but the next request would have to wait 60 seconds.  For now, i set `capacity = 100` and `fill_time_s = 60` because I can't imagine many situations where someone would do 100 requests at once, but I'm waiting to hear from Matt Harmon about what a reasonable rate limit would be.


Also sets the user-agent header to `azmetr (https://github.com/uace-azmet/azmetr/)` so Matt can tell when it's the `azmetr` package making queries and changes the `ping_service()` function to just to a HEAD request instead of GET.