### PR TITLE
Expand units to new functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # azmetr (development version)
 
+- Updated `az_add_units()` to include columns returned by `az_15min()`, `az_lw15min()`, and `az_lwdaily()`
 - Added Duncan station ("az46") to station information
 - tibbles produced by `az_*()` functions now have the "labels" attribute set on columns.  This is used for things like tooltips in the Positron data viewer and default axis labels for `ggplot2` plots (https://tidyverse.org/blog/2025/09/ggplot2-4-0-0/#labels)
 - Updated package to access data from 2020

--- a/R/az_add_units.R
+++ b/R/az_add_units.R
@@ -27,111 +27,108 @@
 az_add_units <- function(x) {
   rlang::check_installed("units")
   x %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "dwpt",
-      "heatstress_cottonC",
-      "temp_airC",
-      "temp_soil_10cmC",
-      "temp_soil_50cmC",
-      "dwpt_mean",
-      "heatstress_cotton_meanC",
-      "temp_air_maxC",
-      "temp_air_meanC",
-      "temp_air_minC",
-      "temp_soil_10cm_maxC",
-      "temp_soil_10cm_meanC",
-      "temp_soil_10cm_minC",
-      "temp_soil_50cm_maxC",
-      "temp_soil_50cm_meanC",
-      "temp_soil_50cm_minC",
-      "heat_units_10C",
-      "heat_units_13C",
-      "heat_units_3413C",
-      "heat_units_7C"
-    )), ~units::set_units(., "degC")
-    )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "dwpt_meanF",
-      "heatstress_cotton_meanF",
-      "temp_air_maxF",
-      "temp_air_meanF",
-      "temp_air_minF",
-      "temp_soil_10cm_maxF",
-      "temp_soil_10cm_meanF",
-      "temp_soil_10cm_minF",
-      "temp_soil_50cm_maxF",
-      "temp_soil_50cm_meanF",
-      "temp_soil_50cm_minF",
-      "dwptF",
-      "heatstress_cottonF",
-      "temp_airF",
-      "temp_soil_10cmF",
-      "temp_soil_50cmF",
-      "heat_units_45F",
-      "heat_units_50F",
-      "heat_units_55F",
-      "heat_units_45F_sum",
-      "heat_units_9455F",
-      "heat_units_50F_sum",
-      "heat_units_55F_sum",
-      "heat_units_9455F_sum"
-    )), ~units::set_units(., "degF")
-    )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "wind_vector_dir",
-      "wind_2min_vector_dir",
-      "wind_vector_dir_stand_dev"
-    )), ~units::set_units(., "degrees")
-    )) %>%
-    dplyr::mutate(dplyr::across(c(
-      dplyr::ends_with("_in"),
-      dplyr::ends_with("_in_sum")
-      ), ~units::set_units(., "in")
-      )) %>%
     dplyr::mutate(dplyr::across(
-      dplyr::starts_with("chill_hours"), ~units::set_units(., "hours")
+      c(
+        dplyr::matches("temp_.+C"),
+        dplyr::matches("heat.+C"),
+        dplyr::starts_with("dwpt"),
+        dplyr::any_of(c(
+          "dwpt",
+          "dwpt_mean",
+          "dwpt",
+          "dwpt_30cm"
+        ))
+      ),
+      function(x) units::set_units(x, "degC")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::starts_with("vp_"),
-                  ~units::set_units(., "kPa")
+    dplyr::mutate(dplyr::across(
+      c(
+        dplyr::matches("temp_.+F"),
+        dplyr::matches("heat.+F"),
+        dplyr::any_of(c(
+          "dwpt_meanF",
+          "dwptF"
+        ))
+      ),
+      function(x) units::set_units(x, "degF")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "sol_rad_total_ly"
-    )), ~units::set_units(., "langleys")
+    dplyr::mutate(dplyr::across(
+      dplyr::matches("^wind_.*_dir"),
+      function(x) units::set_units(x, "degrees")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "sol_rad_total"
-    )), ~units::set_units(., "MJ m-2")
+    dplyr::mutate(dplyr::across(
+      c(
+        dplyr::ends_with("_in"),
+        dplyr::ends_with("_in_sum")
+      ),
+      function(x) units::set_units(x, "in")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "eto_azmet",
-      "precip_total",
-      "eto_pen_mon",
-      "precip_total_mm"
-    )), ~units::set_units(., "mm")
+    dplyr::mutate(dplyr::across(
+      dplyr::starts_with("chill_hours"),
+      function(x) units::set_units(x, "hours")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::matches("^wind.*_mph$"),
-                                ~units::set_units(., "miles/hr")
+    dplyr::mutate(dplyr::across(
+      dplyr::starts_with("vp_"),
+      function(x) units::set_units(x, "kPa")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::matches("^wind.*_mps$"),
-                                ~units::set_units(., "m/s")
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of(c(
+        "sol_rad_total_ly"
+      )),
+      function(x) units::set_units(x, "langleys")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "wind_vector_magnitude"
-    )), ~units::set_units(., "m/s")
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of(c(
+        "sol_rad_total"
+      )),
+      function(x) units::set_units(x, "MJ m-2")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "meta_bat_volt",
-      "meta_bat_volt_max",
-      "meta_bat_volt_mean",
-      "meta_bat_volt_min"
-    )), ~units::set_units(., "V")
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of("sol_rad_kWm2"),
+      function(x) units::set_units(x, "kW m-2")
     )) %>%
-    dplyr::mutate(dplyr::across(dplyr::any_of(c(
-      "relative_humidity_max",
-      "relative_humidity_mean",
-      "relative_humidity_min",
-      "relative_humidity"
-    )), ~units::set_units(., "%")
-    ))
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of(c(
+        "eto_azmet",
+        "precip_total",
+        "eto_pen_mon",
+        "precip_total_mm"
+      )),
+      function(x) units::set_units(x, "mm")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::matches("^wind.*_mph$"),
+      function(x) units::set_units(x, "miles/hr")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::matches("^wind.*_mps"),
+      function(x) units::set_units(x, "m/s")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of(c(
+        "wind_vector_magnitude"
+      )),
+      function(x) units::set_units(x, "m/s")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::any_of(c(
+        "meta_bat_volt",
+        "meta_bat_volt_max",
+        "meta_bat_volt_mean",
+        "meta_bat_volt_min"
+      )),
+      function(x) units::set_units(x, "V")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::starts_with("relative_humidity"),
+      function(x) units::set_units(x, "%")
+    )) %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::matches("lw.+_mV$"),
+      function(x) units::set_units(x, "mV")
+    )) %>%
+    dplyr::mutate(dplyr::across(dplyr::ends_with("_mins"), function(x) {
+      units::set_units(x, "minute")
+    }))
 }
 

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,2 @@
+[format]
+exclude = ["/R/add_labels_*.R"]

--- a/tests/testthat/test-az_add_units.R
+++ b/tests/testthat/test-az_add_units.R
@@ -6,13 +6,35 @@ test_that("all columns get assigned units that should", {
   res_daily <-
     az_daily(station_id = 1, start_date = "2023-11-27", end_date = "2023-11-29")
   res_hourly <-
-    az_hourly(station_id = 1, start_date_time = "2023-11-28 01", end_date_time = "2023-11-28 12")
+    az_hourly(
+      station_id = 1,
+      start_date_time = "2023-11-28 01",
+      end_date_time = "2023-11-28 12"
+    )
   res_heat <-
     az_heat(station_id = 1, end_date = "2023-11-28")
+  res_15min <- az_15min(
+    station_id = 1,
+    start = "2026-03-05 12:00:00",
+    end = "2026-03-05 13:00:00"
+  )
+  res_lw15 <- az_lw15min(
+    station_id = 1,
+    start = "2026-03-05 12:00:00",
+    end = "2026-03-05 13:00:00"
+  )
+  res_lwdaily <- az_lwdaily(
+    station_id = 1,
+    start = "2026-03-03",
+    end = "2026-03-04"
+  )
 
   heat_units <- az_add_units(res_heat)
   hourly_units <- az_add_units(res_hourly)
   daily_units <- az_add_units(res_daily)
+  min15_units <- az_add_units(res_15min)
+  lw15min_units <- az_add_units(res_lw15)
+  lwdaily_units <- az_add_units(res_lwdaily)
   expect_true(
     heat_units %>%
       dplyr::select(-starts_with("meta_"), -datetime_last) %>%
@@ -38,6 +60,37 @@ test_that("all columns get assigned units that should", {
         -wind_2min_timestamp
       ) %>%
       purrr::map_lgl(~inherits(.x, "units")) %>%
+      all()
+  )
+  expect_true(
+    min15_units %>%
+      dplyr::select(
+        -starts_with("meta_"),
+        -datetime,
+        -starts_with("date_"),
+      ) %>%
+      purrr::map_lgl(~ inherits(.x, "units")) %>%
+      all()
+  )
+  expect_true(
+    lw15min_units %>%
+      dplyr::select(
+        -starts_with("meta_"),
+        -datetime,
+        -starts_with("date_"),
+      ) %>%
+      purrr::map_lgl(~ inherits(.x, "units")) %>%
+      all()
+  )
+  expect_true(
+    lwdaily_units %>%
+      dplyr::select(
+        -starts_with("meta_"),
+        -date,
+        -datetime,
+        -starts_with("date_"),
+      ) %>%
+      purrr::map_lgl(~ inherits(.x, "units")) %>%
       all()
   )
 })


### PR DESCRIPTION
Closes #81.  Adjusts `az_add_units()` to match all columns in newer functions.  Also adds an air.toml file that prevents automatic formatting of the add_labels_* function code if you use the [Air formatter](https://tidyverse.org/blog/2025/02/air/).