### PR TITLE
Update error handling for new AWS backend

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          cache-version: 2
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # azmetr (development version)
 
+- The AZMet API was updated to return HTTP error codes for bad requests or server errors and these are now displayed to users.
 - Updated `az_add_units()` to include columns returned by `az_15min()`, `az_lw15min()`, and `az_lwdaily()`
 - Added Duncan station ("az46") to station information
 - tibbles produced by `az_*()` functions now have the "labels" attribute set on columns.  This is used for things like tooltips in the Positron data viewer and default axis labels for `ggplot2` plots (https://tidyverse.org/blog/2025/09/ggplot2-4-0-0/#labels)

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -33,14 +33,12 @@ retrieve_data <-
   }
 
   resp <- req %>%
+    httr2::req_error(body = \(resp) {
+      as.character(httr2::resp_body_json(resp)$errors)
+    }) %>%
     httr2::req_perform()
 
   data_raw <- httr2::resp_body_json(resp)
-
-  if (length(data_raw$errors) > 0) {
-    stop(paste0(data_raw$errors, "\n "))
-  }
-
   data_tidy <- data_raw$data %>%
     purrr::compact() %>%
     purrr::map(purrr::compact) %>% # Removes any columns that are NULL (i.e. no data)

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -23,20 +23,31 @@ retrieve_data <-
 
   req <- httr2::request(base_url) %>%
     httr2::req_method("GET") %>%
-    httr2::req_url_path_append("observations", endpoint, station_id, start_f, time_interval) %>%
+    httr2::req_url_path_append(
+      "observations",
+      endpoint,
+      station_id,
+      start_f,
+      time_interval
+    ) %>%
     httr2::req_headers("Accept" = "application/json") %>%
-    httr2::req_throttle(capacity =  200, fill_time_s = 60) %>%
-    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)")
+    httr2::req_throttle(capacity = 200, fill_time_s = 60) %>%
+    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)") %>%
+    httr2::req_error(body = function(resp) {
+      # Some errors have text body, e.g. 502 bad gateway
+      body <- try(httr2::resp_body_json(resp), silent = TRUE)
+      if (inherits(body, "try-error")) {
+        NULL
+      } else {
+        as.character(body$errors)
+      }
+    })
 
   if (isTRUE(print_call)) {
     print(req)
   }
 
-  resp <- req %>%
-    httr2::req_error(body = function(resp) {
-      as.character(httr2::resp_body_json(resp)$errors)
-    }) %>%
-    httr2::req_perform()
+  resp <- httr2::req_perform(req)
 
   data_raw <- httr2::resp_body_json(resp)
   data_tidy <- data_raw$data %>%

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -33,7 +33,7 @@ retrieve_data <-
   }
 
   resp <- req %>%
-    httr2::req_error(body = \(resp) {
+    httr2::req_error(body = function(resp) {
       as.character(httr2::resp_body_json(resp)$errors)
     }) %>%
     httr2::req_perform()

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,4 +19,5 @@ ping_service <- function() {
   }
 }
 
-base_url <- "https://api.azmet.arizona.edu/v1/"
+# base_url <- "https://api.azmet.arizona.edu/v1/"
+base_url <- "https://api-azmet.colo-prod-aws.arizona.edu/v1"

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,5 +27,4 @@ ping_service <- function() {
   }
 }
 
-# base_url <- "https://api.azmet.arizona.edu/v1/"
-base_url <- "https://api-azmet.colo-prod-aws.arizona.edu/v1"
+base_url <- "https://api.azmet.arizona.edu/v1/"

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,17 +2,25 @@ check_internet <- function(){
   attempt::stop_if_not(.x = curl::has_internet(), msg = "Please check your internet connexion")
 }
 
-ping_service <- function() {
-  resp <-
+check_status <- function() {
+  req <-
     httr2::request(base_url) %>%
-    httr2::req_url_path_append("observations", "daily", "az01") %>%
+    httr2::req_url_path_append("status") %>%
     httr2::req_error(is_error = function(resp) FALSE) %>%
-    httr2::req_method("HEAD") %>%
-    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)") %>% 
-    httr2::req_perform() 
+    httr2::req_user_agent("azmetr (https://github.com/uace-azmet/azmetr)")
 
-  status <- httr2::resp_status(resp)
-  if(status == 200){
+  resp <- httr2::req_perform(req)
+  http_status <- httr2::resp_status(resp)
+  if (http_status != 200) {
+    return(list(status = http_status))
+  } else {
+    httr2::resp_body_json(resp)
+  }
+}
+
+ping_service <- function() {
+  status <- check_status()
+  if (status$status == "OK" & status$statusdb == "OK") {
     return(TRUE)
   } else {
     return(FALSE)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ az_lw15min()
 az_lwdaily()
 ```
 
+Because `azmetr` uses the `httr2` package to handle API requests, you can wrap any `azmetr` function with `with_verbosity()` to get more detailed logging of the actually HTTP requests and response headers.  For example:
+
+```r
+httr2::with_verbosity(az_daily())
+#> Querying data from 2026-05-19
+#> -> GET /v1/observations/daily/*/*/* HTTP/2
+#> -> Host: api.azmet.arizona.edu
+#> -> User-Agent: azmetr (https://github.com/uace-azmet/azmetr)
+#> -> Accept-Encoding: deflate, gzip
+#> -> Accept: application/json
+#> -> 
+#> <- HTTP/2 200 
+#> <- date: Wed, 20 May 2026 21:49:18 GMT
+#> <- content-type: application/json
+#> <- server: -
+#> <- 
+```
+
 ## Code of Conduct
   
   Please note that the `azmetr` project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.

--- a/tests/testthat/test-az_heat.R
+++ b/tests/testthat/test-az_heat.R
@@ -18,17 +18,17 @@ test_that("az_heat() returns only one row per station even with dates", {
 })
 
 test_that("start and end dates interpreted correctly", {
-  res <- az_heat(station_id = 1, start_date = "2023-10-10", end_date = "2023-10-30")
+  res <- az_heat(
+    station_id = 1,
+    start_date = "2023-10-10",
+    end_date = "2023-10-30"
+  )
 
   expect_equal(
     res$datetime_last,
     lubridate::ymd("2023-10-30"),
     ignore_attr = TRUE
   )
-
-
-  skip("not sure of desired behavior")
-  expect_error(az_heat(station_id = 1, end_date = "2022-09-01"), "`end_date` is before `start_date`!")
 })
 
 test_that("end_date can be specified without start_date", {
@@ -39,8 +39,11 @@ test_that("end_date can be specified without start_date", {
   expect_s3_class(res_end_yesterday, "data.frame")
   expect_equal(res_end_yesterday$datetime_last, yesterday, ignore_attr = TRUE)
 
-  skip("not sure of desired behavior here")
-  expect_equal(res_end_old$datetime_last, lubridate::ymd("2022-09-27"))
+  expect_equal(
+    res_end_old$datetime_last,
+    lubridate::ymd("2022-09-27"),
+    ignore_attr = TRUE
+  )
 })
 
 test_that("works with station_id as a vector", {


### PR DESCRIPTION
Closes #105.  New AWS backend returns HTTP error response codes with bad requests now rather than 200 responses.  Without this PR, the updated API wouldn't break things, but the error message would become less informative ("404 Bad Response" instead of "Station not found").  This surfaces the error messages contained in 404 responses (and all HTTP error responses) to the user.
