### PR TITLE
Update `az_15min()` documentation, tests, and examples to reflect 14 days of data

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^pkgdown$
 ^data-raw$
 ^.vscode$
+^air.toml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     tidyselect
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 URL: https://uace-azmet.github.io/azmetr/, https://uace-azmet.r-universe.dev/azmetr
 BugReports: https://github.com/uace-azmet/azmetr/issues
 Suggests: 

--- a/R/az_15min.R
+++ b/R/az_15min.R
@@ -23,8 +23,8 @@
 #' @note If `station_id` is supplied as a vector, multiple successive calls to
 #'   the API will be made. You may find better performance getting data for all
 #'   the stations by leaving `station_id` blank and subsetting the resulting
-#'   dataframe. Only the most recent 48 hours of 15-minute data are stored in
-#'   the AZMet API.
+#'   dataframe. Only the most recent 14 days of 15-minute data are stored in the
+#'   AZMet API.
 #' @return A tibble. For units and other metadata, see
 #'   <https://azmet.arizona.edu/about>
 #' @seealso [az_daily()], [az_heat()], [az_hourly()], [az_lw15min()], [az_lwdaily()]
@@ -41,9 +41,14 @@
 #' az_15min(station_id = c(1, 2))
 #' az_15min(station_id = c("az01", "az02"))
 #'
-#' # Specify dates:
-#' az_15min(start_date_time = "2022-09-25 01:00:00")
-#' az_15min(start_date_time = "2022-09-25 01:00:00", end_date_time = "2022-09-25 07:00:00")
+#' # Last 5 hours of 15 min data
+#' az_15min(start_date_time = lubridate::now() - lubridate::hours(5))
+#' 
+#' # A specific time range (note: only the last 14 days of data are available in the API)
+#' az_15min(
+#'   start_date_time = lubridate::now() - lubridate::days(14),
+#'   end_date_time = lubridate::now() - lubridate::days(13)
+#' )
 #' }
 
 

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -194,6 +194,14 @@ parse_params <- function(station_id, start, end, hour = FALSE, real_time = FALSE
     if (end_parsed < start_parsed) {
       stop("`end_date_time` is before `start_date_time`!")
     }
+    if (
+      !is.null(start) &
+        start_parsed < lubridate::now(tzone = tz) - lubridate::days(14)
+    ) {
+      warning(
+        "Only the previous 14 days of 15-minute data are available in the API"
+      )
+    }
   } else { # Daily weather and leaf wetness data
     if (!is.null(start) & start_parsed >= lubridate::today(tzone = tz)) {
       stop("Please supply a `start_date` earlier than today.")

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -209,9 +209,9 @@ parse_params <- function(station_id, start, end, hour = FALSE, real_time = FALSE
   if (length(station_id) == 1 & "*" %in% station_id) {
     earliest_date <- min(station_info$start_date)
   } else {
-    earliest_date <- station_info |>
-      dplyr::filter(.data$meta_station_id %in% station_id) |>
-      dplyr::pull(.data$start_date) |>
+    earliest_date <- station_info %>%
+      dplyr::filter(.data$meta_station_id %in% station_id) %>%
+      dplyr::pull(.data$start_date) %>%
       min()
   }
 

--- a/R/parse_params.R
+++ b/R/parse_params.R
@@ -40,7 +40,7 @@ parse_params <- function(station_id, start, end, hour = FALSE, real_time = FALSE
       stop("`station_id` must be numeric or character in the format 'az01'.")
     }
 
-    active_stations <- station_info$meta_station_id
+    active_stations <- azmetr::station_info$meta_station_id
 
     if(!all(station_id %in% active_stations)) {
       stop("Invalid `station_id`")
@@ -207,9 +207,9 @@ parse_params <- function(station_id, start, end, hour = FALSE, real_time = FALSE
   }
 
   if (length(station_id) == 1 & "*" %in% station_id) {
-    earliest_date <- min(station_info$start_date)
+    earliest_date <- min(azmetr::station_info$start_date)
   } else {
-    earliest_date <- station_info %>%
+    earliest_date <- azmetr::station_info %>%
       dplyr::filter(.data$meta_station_id %in% station_id) %>%
       dplyr::pull(.data$start_date) %>%
       min()

--- a/man/az_15min.Rd
+++ b/man/az_15min.Rd
@@ -44,8 +44,8 @@ only \code{end_date_time} will result in an error.
 If \code{station_id} is supplied as a vector, multiple successive calls to
 the API will be made. You may find better performance getting data for all
 the stations by leaving \code{station_id} blank and subsetting the resulting
-dataframe. Only the most recent 48 hours of 15-minute data are stored in
-the AZMet API.
+dataframe. Only the most recent 14 days of 15-minute data are stored in the
+AZMet API.
 }
 \examples{
 \dontrun{

--- a/man/az_15min.Rd
+++ b/man/az_15min.Rd
@@ -56,9 +56,14 @@ az_15min()
 az_15min(station_id = c(1, 2))
 az_15min(station_id = c("az01", "az02"))
 
-# Specify dates:
-az_15min(start_date_time = "2022-09-25 01:00:00")
-az_15min(start_date_time = "2022-09-25 01:00:00", end_date_time = "2022-09-25 07:00:00")
+# Last 5 hours of 15 min data
+az_15min(start_date_time = lubridate::now() - lubridate::hours(5))
+
+# A specific time range (note: only the last 14 days of data are available in the API)
+az_15min(
+  start_date_time = lubridate::now() - lubridate::days(14),
+  end_date_time = lubridate::now() - lubridate::days(13)
+)
 }
 }
 \seealso{

--- a/tests/testthat/test-az_15min.R
+++ b/tests/testthat/test-az_15min.R
@@ -41,10 +41,12 @@ test_that("data is in correct format", {
 })
 
 test_that("no data is returned as 0x0 tibble", {
-  skip("not sure how to reproduce this now that request for historical data error")
   res_nodata <-
     suppressWarnings(
-      az_15min(start_date_time = "1980-01-01 00", end_date_time = "1980-01-02 00")
+      az_15min(
+        start_date_time = lubridate::now() - lubridate::days(20),
+        end_date_time = lubridate::now() - lubridate::days(19)
+      )
     )
   expect_true(nrow(res_nodata) == 0)
   expect_s3_class(res_nodata, "tbl_df")

--- a/tests/testthat/test-az_add_units.R
+++ b/tests/testthat/test-az_add_units.R
@@ -15,8 +15,8 @@ test_that("all columns get assigned units that should", {
     az_heat(station_id = 1, end_date = "2023-11-28")
   res_15min <- az_15min(
     station_id = 1,
-    start = lubridate::now() - lubridate::hours(6),
-    end = lubridate::now() - lubridate::hours(5)
+    start = lubridate::now(tzone = "America/Phoenix") - lubridate::hours(24),
+    end = lubridate::now(tzone = "America/Phoenix") - lubridate::hours(23)
   )
   res_lw15 <- az_lw15min(
     station_id = 1,

--- a/tests/testthat/test-az_add_units.R
+++ b/tests/testthat/test-az_add_units.R
@@ -15,8 +15,8 @@ test_that("all columns get assigned units that should", {
     az_heat(station_id = 1, end_date = "2023-11-28")
   res_15min <- az_15min(
     station_id = 1,
-    start = "2026-03-05 12:00:00",
-    end = "2026-03-05 13:00:00"
+    start = lubridate::now() - lubridate::hours(6),
+    end = lubridate::now() - lubridate::hours(5)
   )
   res_lw15 <- az_lw15min(
     station_id = 1,

--- a/tests/testthat/test-az_heat.R
+++ b/tests/testthat/test-az_heat.R
@@ -54,7 +54,7 @@ test_that("data is in correct format", {
   res_default <- az_heat()
 
   expect_s3_class(res_default, "data.frame")
-  expect_equal(nrow(res_default), nrow(station_info))
+  expect_equal(nrow(res_default), nrow(azmetr::station_info))
   expect_type(res_default$meta_station_name, "character")
   expect_type(res_default$eto_pen_mon_in, "double")
   expect_s3_class(res_default$datetime_last, "Date")

--- a/tests/testthat/test-parse_params.R
+++ b/tests/testthat/test-parse_params.R
@@ -169,7 +169,7 @@ test_that("start and end has to be earlier than now", {
 })
 
 test_that("requests for historical data error", {
-  start_date <- min(station_info$start_date) - months(1)
+  start_date <- min(azmetr::station_info$start_date) - months(1)
   expect_error(
     parse_params(1, start = start_date, end = start_date + months(1))
   )


### PR DESCRIPTION
Closes #108.  Updates documentation, tests, and examples to reflect that only the latest 14 days of 15 min data is stored on the API.

TODO:
- [x] Add an additional check and warning when user requests data from more than 14 days ago.
