### PR TITLE
Fix missing data warnings with default requests

### DIFF
--- a/R/az_15min.R
+++ b/R/az_15min.R
@@ -121,14 +121,18 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
     return(tibble::tibble())
   }
 
-  # Check if any data is missing. Note, this always "passes" when both start and
-  # end are NULL (because period("*") is NA)
-  #n_obs <- out %>%
-  #  dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
-  #  dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "hour"))
-  #if (nrow(n_obs) != 0) {
-  #  warning("Some requested data were unavailable.")
-  #}
+  # Check if any data is missing.
+  # Default period appears to be 15 minutes.  Gives same result as "*"
+  p <- if (params$time_interval == "*") "PT15M" else params$time_interval
+  n_obs <- out %>%
+    dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
+    dplyr::filter(
+      # Predicted number of observations that should be returned
+      .data$n < (as.numeric(lubridate::period(p), "minutes") + 15) / 15
+    )
+  if (nrow(n_obs) != 0) {
+    warning("Some requested data were unavailable.")
+  }
 
   # Warn if the missing data is just at the end
   if (lubridate::ymd_hms(max(out$datetime), tz = tz) < params$end) {

--- a/R/az_15min.R
+++ b/R/az_15min.R
@@ -43,7 +43,7 @@
 #'
 #' # Last 5 hours of 15 min data
 #' az_15min(start_date_time = lubridate::now() - lubridate::hours(5))
-#' 
+#'
 #' # A specific time range (note: only the last 14 days of data are available in the API)
 #' az_15min(
 #'   start_date_time = lubridate::now() - lubridate::days(14),
@@ -51,15 +51,19 @@
 #' )
 #' }
 
-
-az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = NULL) {
-
+az_15min <- function(
+  station_id = NULL,
+  start_date_time = NULL,
+  end_date_time = NULL
+) {
   # TODO: check for valid station IDs
 
   check_internet()
 
   if (!is.null(end_date_time) & is.null(start_date_time)) {
-    stop("If you supply `end_date_time`, you must also supply `start_date_time`.")
+    stop(
+      "If you supply `end_date_time`, you must also supply `start_date_time`."
+    )
   }
 
   params <-
@@ -73,14 +77,17 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
 
   tz <- "America/Phoenix"
 
-
   # Query API ------------------------------------------------------------------
 
   if (is.null(start_date_time) & is.null(end_date_time)) {
     message("Querying most recent datetime of 15-minute data ...")
   } else {
     message(
-      "Querying data from ", format(params$start, "%Y-%m-%d %H:%M:%S")," through ", format(params$end, "%Y-%m-%d %H:%M:%S"), " ..."
+      "Querying data from ",
+      format(params$start, "%Y-%m-%d %H:%M:%S"),
+      " through ",
+      format(params$end, "%Y-%m-%d %H:%M:%S"),
+      " ..."
     )
   }
 
@@ -112,7 +119,10 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
   if (is.null(start_date_time) & is.null(end_date_time)) {
     out <-
       out %>%
-      dplyr::filter(.data$datetime == max(.data$datetime), .by = "meta_station_id")
+      dplyr::filter(
+        .data$datetime == max(.data$datetime),
+        .by = "meta_station_id"
+      )
   }
 
   if (nrow(out) == 0) {
@@ -122,7 +132,7 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
   }
 
   # Check if any data is missing.
-  # Default period appears to be 15 minutes.  Gives same result as "*"
+  # Default period from the API is 24 hrs, but azmetr only shows last 15 min.
   p <- if (params$time_interval == "*") "PT15M" else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
@@ -137,10 +147,13 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
   # Warn if the missing data is just at the end
   if (lubridate::ymd_hms(max(out$datetime), tz = tz) < params$end) {
     warning(
-      "You requested data through ", params$end, " but only data through ", max(out$datetime), " were available."
+      "You requested data through ",
+      params$end,
+      " but only data through ",
+      max(out$datetime),
+      " were available."
     )
   }
-
 
   # Wrangle output -------------------------------------------------------------
 
@@ -175,10 +188,17 @@ az_15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = 
     add_labels_15min()
 
   if (length(unique(out$datetime)) == 1) {
-    message("Returning data from ", format(unique(out$datetime), "%Y-%m-%d %H:%M:%S"))
+    message(
+      "Returning data from ",
+      format(unique(out$datetime), "%Y-%m-%d %H:%M:%S")
+    )
   } else {
     message(
-      "Returning data from ", format(min(out$datetime), "%Y-%m-%d %H:%M:%S"), " through ", format(max(out$datetime), "%Y-%m-%d %H:%M:%S"))
+      "Returning data from ",
+      format(min(out$datetime), "%Y-%m-%d %H:%M:%S"),
+      " through ",
+      format(max(out$datetime), "%Y-%m-%d %H:%M:%S")
+    )
   }
 
   return(out)

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -112,7 +112,7 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   p <- if (params$time_interval == "*") "PT0S" else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
-    dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "day") + 1)
+    dplyr::filter(.data$n < as.numeric(lubridate::period(p), "day") + 1)
   if (nrow(n_obs) != 0 |
      # Also warn if the missing data is just at the end
      lubridate::ymd(max(out$datetime), tz = tz) < params$end) {

--- a/R/az_daily.R
+++ b/R/az_daily.R
@@ -108,6 +108,8 @@ az_daily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   }
 
   # Check if any data are missing
+  # Default period is 0 seconds—gives same results as "*"
+  p <- if (params$time_interval == "*") "PT0S" else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
     dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "day") + 1)

--- a/R/az_hourly.R
+++ b/R/az_hourly.R
@@ -48,68 +48,94 @@
 #' az_hourly(start_date_time = "2022-09-25 01", end_date = "2022-09-25 20")
 #' }
 #'
-az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time = NULL) {
-
+az_hourly <- function(
+  station_id = NULL,
+  start_date_time = NULL,
+  end_date_time = NULL
+) {
   # TODO: check for valid station IDs
   check_internet()
-  if(!is.null(end_date_time) & is.null(start_date_time)) {
-    stop("If you supply `end_date_time`, you must also supply `start_date_time`")
+  if (!is.null(end_date_time) & is.null(start_date_time)) {
+    stop(
+      "If you supply `end_date_time`, you must also supply `start_date_time`"
+    )
   }
   params <-
-    parse_params(station_id = station_id, start = start_date_time,
-                 end = end_date_time, hour = TRUE)
+    parse_params(
+      station_id = station_id,
+      start = start_date_time,
+      end = end_date_time,
+      hour = TRUE
+    )
 
   # Query API --------------------------------------------
   if (is.null(start_date_time) & is.null(end_date_time)) {
     message("Querying most recent hour of data ...")
   } else {
-    message("Querying data from ", format(params$start, "%Y-%m-%d %H:%M"),
-            " through ", format(params$end, "%Y-%m-%d %H:%M"))
+    message(
+      "Querying data from ",
+      format(params$start, "%Y-%m-%d %H:%M"),
+      " through ",
+      format(params$end, "%Y-%m-%d %H:%M")
+    )
   }
 
   if (length(station_id) <= 1) {
     out <-
-      retrieve_data(params$station_id,
-                    params$start_f,
-                    params$time_interval,
-                    endpoint = "hourly")
+      retrieve_data(
+        params$station_id,
+        params$start_f,
+        params$time_interval,
+        endpoint = "hourly"
+      )
   } else if (length(station_id) > 1) {
     out <-
       purrr::map_df(
         params$station_id,
         function(x) {
-          retrieve_data(x,
-                        params$start_f,
-                        params$time_interval,
-                        endpoint = "hourly")
+          retrieve_data(
+            x,
+            params$start_f,
+            params$time_interval,
+            endpoint = "hourly"
+          )
         }
       )
   }
 
   # If most recent hour is queried, make sure only one hour is returned
   if (is.null(start_date_time) & is.null(end_date_time)) {
-  out <-
-    out %>%
-    dplyr::filter(.data$date_datetime == max(.data$date_datetime), .by = "meta_station_id")
+    out <-
+      out %>%
+      dplyr::filter(
+        .data$date_datetime == max(.data$date_datetime),
+        .by = "meta_station_id"
+      )
   }
 
-  if(nrow(out) == 0) {
+  if (nrow(out) == 0) {
     warning("No data retrieved from API")
     #return 0x0 tibble
     return(tibble::tibble())
   }
 
-  #Check if any data is missing
-  #Note, this always "passes" when both start and end are NULL (because period("*") is NA)
+  # Check if any data is missing
+  # Default period of 1 hour gives same results as "*"
+  p <- if (params$time_interval == "*") "PT1H" else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
-    dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "hour"))
-  if(nrow(n_obs) != 0) {
+    dplyr::filter(
+      .data$n < as.numeric(lubridate::period(p), "hour")
+    )
+  if (nrow(n_obs) != 0) {
     warning("Some requested data were unavailable")
   }
 
-  #Warn if the missing data is just at the end
-  if (lubridate::ymd_hms(max(out$date_datetime), tz = "America/Phoenix") < params$end) {
+  # Warn if the missing data is just at the end
+  if (
+    lubridate::ymd_hms(max(out$date_datetime), tz = "America/Phoenix") <
+      params$end
+  ) {
     warning(
       "You requested data through ",
       params$end,
@@ -118,7 +144,6 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
       " were available"
     )
   }
-
 
   # Wrangle output ----------------------------------------------------------
   out <- out %>%
@@ -174,10 +199,17 @@ az_hourly <- function(station_id = NULL, start_date_time = NULL, end_date_time =
     add_labels_hourly()
 
   if (length(unique(out$date_datetime)) == 1) {
-    message("Returning data from ", format(unique(out$date_datetime), "%Y-%m-%d %H:%M"))
+    message(
+      "Returning data from ",
+      format(unique(out$date_datetime), "%Y-%m-%d %H:%M")
+    )
   } else {
-    message("Returning data from ", format(min(out$date_datetime), "%Y-%m-%d %H:%M"),
-            " through ", format(max(out$date_datetime), "%Y-%m-%d %H:%M"))
+    message(
+      "Returning data from ",
+      format(min(out$date_datetime), "%Y-%m-%d %H:%M"),
+      " through ",
+      format(max(out$date_datetime), "%Y-%m-%d %H:%M")
+    )
   }
   return(out)
 }

--- a/R/az_lw15min.R
+++ b/R/az_lw15min.R
@@ -47,15 +47,19 @@
 #' az_lw15min(start_date_time = "2022-09-25 01:00:00", end_date_time = "2022-09-25 07:00:00")
 #' }
 
-
-az_lw15min <- function(station_id = NULL, start_date_time = NULL, end_date_time = NULL) {
-
+az_lw15min <- function(
+  station_id = NULL,
+  start_date_time = NULL,
+  end_date_time = NULL
+) {
   # TODO: check for valid station IDs
 
   check_internet()
 
   if (!is.null(end_date_time) & is.null(start_date_time)) {
-    stop("If you supply `end_date_time`, you must also supply `start_date_time`.")
+    stop(
+      "If you supply `end_date_time`, you must also supply `start_date_time`."
+    )
   }
 
   params <-
@@ -69,14 +73,17 @@ az_lw15min <- function(station_id = NULL, start_date_time = NULL, end_date_time 
 
   tz <- "America/Phoenix"
 
-
   # Query API ------------------------------------------------------------------
 
   if (is.null(start_date_time) & is.null(end_date_time)) {
     message("Querying most recent datetime of leaf wetness 15-minute data ...")
   } else {
     message(
-      "Querying data from ", format(params$start, "%Y-%m-%d %H:%M:%S")," through ", format(params$end, "%Y-%m-%d %H:%M:%S"), " ..."
+      "Querying data from ",
+      format(params$start, "%Y-%m-%d %H:%M:%S"),
+      " through ",
+      format(params$end, "%Y-%m-%d %H:%M:%S"),
+      " ..."
     )
   }
 
@@ -108,7 +115,10 @@ az_lw15min <- function(station_id = NULL, start_date_time = NULL, end_date_time 
   if (is.null(start_date_time) & is.null(end_date_time)) {
     out <-
       out %>%
-      dplyr::filter(.data$datetime == max(.data$datetime), .by = "meta_station_id")
+      dplyr::filter(
+        .data$datetime == max(.data$datetime),
+        .by = "meta_station_id"
+      )
   }
 
   if (nrow(out) == 0) {
@@ -117,22 +127,29 @@ az_lw15min <- function(station_id = NULL, start_date_time = NULL, end_date_time 
     return(tibble::tibble())
   }
 
-  # Check if any data are missing. Note, this always "passes" when both start and
-  # end are NULL (because period("*") is NA)
-  #n_obs <- out %>%
-  #  dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
-  #  dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "hour"))
-  #if (nrow(n_obs) != 0) {
-  #  warning("Some requested data were unavailable.")
-  #}
+  # Check if any data are missing.
+  # Default period is 0 seconds—gives same results as "*"
+  p <- if (params$time_interval == "*") "PT0S" else params$time_interval
+  n_obs <- out %>%
+    dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
+    dplyr::filter(
+      # Predicted number of observations that should be returned
+      .data$n < (as.numeric(lubridate::period(p), "minutes") + 15) / 15
+    )
+  if (nrow(n_obs) != 0) {
+    warning("Some requested data were unavailable.")
+  }
 
   # Warn if the missing data are just at the end
   if (lubridate::ymd_hms(max(out$datetime), tz = tz) < params$end) {
     warning(
-      "You requested data through ", params$end, " but only data through ", max(out$datetime), " were available."
+      "You requested data through ",
+      params$end,
+      " but only data through ",
+      max(out$datetime),
+      " were available."
     )
   }
-
 
   # Wrangle output -------------------------------------------------------------
 
@@ -167,10 +184,17 @@ az_lw15min <- function(station_id = NULL, start_date_time = NULL, end_date_time 
     add_labels_lw15min()
 
   if (length(unique(out$datetime)) == 1) {
-    message("Returning data from ", format(unique(out$datetime), "%Y-%m-%d %H:%M:%S"))
+    message(
+      "Returning data from ",
+      format(unique(out$datetime), "%Y-%m-%d %H:%M:%S")
+    )
   } else {
     message(
-      "Returning data from ", format(min(out$datetime), "%Y-%m-%d %H:%M:%S"), " through ", format(max(out$datetime), "%Y-%m-%d %H:%M:%S"))
+      "Returning data from ",
+      format(min(out$datetime), "%Y-%m-%d %H:%M:%S"),
+      " through ",
+      format(max(out$datetime), "%Y-%m-%d %H:%M:%S")
+    )
   }
 
   return(out)

--- a/R/az_lwdaily.R
+++ b/R/az_lwdaily.R
@@ -106,16 +106,24 @@ az_lwdaily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   }
 
   # Check if any data are missing
-  p <- if (params$time_interval == "*") 1 else params$time_interval
+  # Default period is 0 seconds—gives same results as "*"
+  p <- if (params$time_interval == "*") "PT0S" else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
     dplyr::filter(.data$n < as.numeric(lubridate::period(p), "day") + 1)
 
-  # Also warn if the missing data is just at the end
-  if (
-    nrow(n_obs) != 0 | lubridate::ymd(max(out$date, na.rm = TRUE)) < params$end
-  ) {
+  if (nrow(n_obs) != 0) {
     warning("Some requested data were unavailable.")
+  }
+  # Also warn if the missing data is just at the end
+  if (lubridate::ymd(max(out$date, na.rm = TRUE)) < params$end) {
+    warning(
+      "You requested data through ",
+      params$end,
+      " but only data through ",
+      max(out$datetime),
+      " were available."
+    )
   }
 
 

--- a/R/az_lwdaily.R
+++ b/R/az_lwdaily.R
@@ -106,12 +106,15 @@ az_lwdaily <- function(station_id = NULL, start_date = NULL, end_date = NULL) {
   }
 
   # Check if any data are missing
+  p <- if (params$time_interval == "*") 1 else params$time_interval
   n_obs <- out %>%
     dplyr::summarise(n = dplyr::n(), .by = dplyr::all_of("meta_station_id")) %>%
-    dplyr::filter(.data$n < as.numeric(lubridate::period(params$time_interval), "day") + 1)
-  if (nrow(n_obs) != 0 |
-     # Also warn if the missing data is just at the end
-     lubridate::ymd(max(out$date)) < params$end) {
+    dplyr::filter(.data$n < as.numeric(lubridate::period(p), "day") + 1)
+
+  # Also warn if the missing data is just at the end
+  if (
+    nrow(n_obs) != 0 | lubridate::ymd(max(out$date, na.rm = TRUE)) < params$end
+  ) {
     warning("Some requested data were unavailable.")
   }
 

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -62,6 +62,4 @@ retrieve_data <-
       list(i = data_raw$i, l = data_raw$l, s = data_raw$s, t = data_raw$t)
     )
   data_tidy
-
-  # TODO: Check for 0x0 tibble and error
 }

--- a/tests/testthat/test-az_lwdaily.R
+++ b/tests/testthat/test-az_lwdaily.R
@@ -2,6 +2,10 @@ skip_if_offline()
 skip_if_not(ping_service())
 skip_on_cran()
 
+test_that("works with default args", {
+  expect_s3_class(az_lwdaily(), "data.frame")
+})
+
 test_that("numeric station_ids work", {
   res_station <- az_lwdaily(station_id = 9)
   expect_s3_class(res_station, "data.frame")


### PR DESCRIPTION
Previously, we inconsistently warned about missing data by looking for an expected number of observations given the time interval requested.  However, this wasn't working when the time interval was the default of `"*"`.  This PR updates that warning by *inferring* the default interval and expected number of observations given the interval.